### PR TITLE
DOCS-3168 add xref validator to pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,8 @@ pipeline {
           nodejs('node8') {
             script {
               try {
-                sh '$(npm bin)/antora --pull --stacktrace --html-url-extension-style=drop --redirect-facility=nginx antora-production-playbook.yml > build/build.log 2>&1'
+                sh '$(npm bin)/antora --pull --stacktrace --generator=./generator/xref-validator antora-production-playbook.yml'
+                sh '$(npm bin)/antora --stacktrace --html-url-extension-style=drop --redirect-facility=nginx antora-production-playbook.yml > build/build.log 2>&1'
                 if (fileExists('build/site/.etc/nginx/rewrite.conf')) {
                   sh 'cat etc/nginx/includes/rewrites.conf build/site/.etc/nginx/rewrite.conf > build/rewrites.conf'
                 } else {

--- a/generator/xref-validator.js
+++ b/generator/xref-validator.js
@@ -1,0 +1,92 @@
+'use strict'
+/* Copyright (c) 2018 OpenDevise, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scans converted pages and navigation files for broken xrefs; if any broken
+ * xrefs are detected, outputs a report and exits with a failure code.
+ *
+ * Usage (from root of playbook repository):
+ *
+ *  $ antora --pull --generator=./generator/xref-validator.js antora-production-playbook.yml
+ */
+const aggregateContent = require('@antora/content-aggregator')
+const buildPlaybook = require('@antora/playbook-builder')
+const classifyContent = require('@antora/content-classifier')
+const { convertDocument } = require('@antora/document-converter')
+const { resolveConfig: resolveAsciiDocConfig } = require('@antora/asciidoc-loader')
+
+const BROKEN_XREF_RX = /<a href="#">([^>]+\.adoc)(#[^<]+)?<\/a>/g
+
+module.exports = async (args, env) => {
+  const playbook = buildPlaybook(args, env)
+  const contentCatalog = await aggregateContent(playbook).then((aggregate) => classifyContent(playbook, aggregate))
+  const asciidocConfig = resolveAsciiDocConfig(playbook)
+  const docsWithBrokenXrefs = new Map()
+  const unsilenceStderr = silenceStderr()
+  contentCatalog
+    .getFiles()
+    .filter((file) => (file.src.family === 'page' && file.out) || file.src.family === 'nav')
+    .forEach((doc) => {
+      convertDocument(doc, contentCatalog, asciidocConfig)
+      if (doc.contents.includes('href="#"')) {
+        const brokenXrefs = new Set()
+        const contents = doc.contents.toString()
+        let match
+        while ((match = BROKEN_XREF_RX.exec(contents))) {
+          const [, pageSpec, hash ] = match
+          // Q: should we report the while xref or just the target?
+          brokenXrefs.add(pageSpec)
+        }
+        docsWithBrokenXrefs.set(doc, [ ...brokenXrefs ])
+      }
+    })
+  unsilenceStderr()
+  if (docsWithBrokenXrefs.size) {
+    const byOrigin = Array.from(docsWithBrokenXrefs).reduce((accum, [page, xrefs]) => {
+      let origin
+      const originData = page.src.origin
+      let startPath = ''
+      if (originData.worktree) {
+        origin = [
+          `worktree: ${originData.editUrlPattern.slice(7, originData.editUrlPattern.length - 3)}`,
+          `component: ${page.src.component}`,
+          `version: ${page.src.version}`,
+        ].join(' | ')
+      } else {
+        if (originData.startPath) startPath = `${originData.startPath}/`
+        origin = [
+          `repo: ${originData.url.split(':').pop().replace(/\.git$/, '')}`,
+          `branch: ${originData.branch}`,
+          `component: ${page.src.component}`,
+          `version: ${page.src.version}`,
+        ].join(' | ')
+      }
+      if (!(origin in accum)) accum[origin] = []
+      accum[origin].push({ path: `${startPath}${page.path}`, xrefs })
+      return accum
+    }, {})
+    console.error('Invalid Xrefs Detected:')
+    console.error()
+    Object.keys(byOrigin).sort().forEach((origin) => {
+      console.error(origin)
+      byOrigin[origin].sort((a, b) => a.path.localeCompare(b.path)).forEach(({ path, xrefs }) => {
+        //console.error(`  path: ${path}`)
+        //xrefs.forEach((xref) => console.error(`    ${xref}`))
+        xrefs.forEach((xref) => console.error(`  path: ${path} | xref: ${xref}`))
+      })
+      console.error()
+    })
+    console.error('antora: xref validation failed! See previous report for details.')
+    process.exitCode = 1
+  }
+}
+
+function silenceStderr () {
+  const stderrWriter = process.stderr.write
+  process.stderr.write = () => {}
+  return () => { process.stderr.write = stderrWriter }
+}


### PR DESCRIPTION
This commit adds an xref validator to the pipeline. The xref validator is a custom generator for Antora that gets passed to the `antora` command. The generator runs just enough of the pipeline to be able to scan for broken xrefs in pages and navigation files. If broken xrefs are found, the generator returns a non-zero exit code and halts the pipeline. If no broken xrefs are found, Antora is run again using the default generator which generates the complete site.